### PR TITLE
Remove Studio settings from .env.sample for self-hosting #26578 

### DIFF
--- a/apps/design-system/__registry__/index.tsx
+++ b/apps/design-system/__registry__/index.tsx
@@ -192,6 +192,39 @@ export const Index: Record<string, any> = {
       subcategory: "undefined",
       chunks: []
     },
+    "button-sizes": {
+      name: "button-sizes",
+      type: "components:example",
+      registryDependencies: ["button"],
+      component: React.lazy(() => import("@/registry/default/example/button-sizes")),
+      source: "",
+      files: ["registry/default/example/button-sizes.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
+    "button-default": {
+      name: "button-default",
+      type: "components:example",
+      registryDependencies: ["button"],
+      component: React.lazy(() => import("@/registry/default/example/button-default")),
+      source: "",
+      files: ["registry/default/example/button-default.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
+    "button-warning": {
+      name: "button-warning",
+      type: "components:example",
+      registryDependencies: ["button"],
+      component: React.lazy(() => import("@/registry/default/example/button-warning")),
+      source: "",
+      files: ["registry/default/example/button-warning.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
     "button-secondary": {
       name: "button-secondary",
       type: "components:example",

--- a/apps/design-system/content/docs/components/button.mdx
+++ b/apps/design-system/content/docs/components/button.mdx
@@ -7,44 +7,6 @@ component: true
 
 <ComponentPreview name="button-demo" peekCode wide />
 
-## Installation
-
-<Tabs defaultValue="cli">
-
-<TabsList>
-  <TabsTrigger value="cli">CLI</TabsTrigger>
-  <TabsTrigger value="manual">Manual</TabsTrigger>
-</TabsList>
-<TabsContent value="cli">
-
-```bash
-npx shadcn-ui@latest add button
-```
-
-</TabsContent>
-
-<TabsContent value="manual">
-
-<Steps>
-
-<Step>Install the following dependencies:</Step>
-
-```bash
-npm install @radix-ui/react-slot
-```
-
-<Step>Copy and paste the following code into your project.</Step>
-
-<ComponentSource name="button" />
-
-<Step>Update the import paths to match your project setup.</Step>
-
-</Steps>
-
-</TabsContent>
-
-</Tabs>
-
 ## Usage
 
 ```tsx
@@ -52,8 +14,10 @@ import { Button } from '@/components/ui/button'
 ```
 
 ```tsx
-<Button variant="outline">Button</Button>
+<Button type="outline">Button</Button>
 ```
+
+_It is likely that the `type` prop will be changed to `variant` in the future._
 
 ## Link
 
@@ -77,42 +41,84 @@ Alternatively, you can set the `asChild` parameter and nest the link component.
 
 ## Examples
 
-### Primary
+### Sizes
 
-<ComponentPreview name="button-demo" peekCode wide />
+Use the `size` prop to determine the size of the button.
 
-### Secondary
+<ComponentPreview name="button-sizes" />
+
+### Types
+
+These are all the different `type` variations.
+
+#### Primary
+
+Used for data insertion actions, confirming purchases, strong positive actions.
+
+<ComponentPreview name="button-demo" />
+
+#### Default
+
+Used for opening dialogs, navigating to pages, and other non CRUD actions.
+
+This `type` will probably be the most used button type.
+It will probably be changed to be the default type in future.
+
+<ComponentPreview name="button-default" />
+
+#### Secondary
+
+Can be used for signaling a data or config change, but not as serious as a primary button.
+For destructuve or side effect actions, use the `destructive` or `warning` type.
 
 <ComponentPreview name="button-secondary" />
 
-### Destructive
+#### Warning
+
+Used for actions that might have a side effect, but not as serious as a destructive action.
+
+<ComponentPreview name="button-warning" />
+
+#### Destructive (currently `danger`)
+
+Used for actions that will have a serios destructive side effect, like deleting data.
+
+prop `type` will probably be changed to `destructive` in the future.
 
 <ComponentPreview name="button-destructive" />
 
-### Outline
+#### Outline
+
+Used for secondary actions, or actions that are not as important as the primary action.
 
 <ComponentPreview name="button-outline" />
 
-### Ghost
+#### Ghost (currently `text`)
+
+Used for actions that are not as important as the primary action, or for actions that are not as important as the primary action.
+
+prop `type` will probably be changed to `ghost` in the future.
 
 <ComponentPreview name="button-ghost" />
 
-### Link
+#### Link
+
+Used for actions that are not as important as the primary action, or for actions that are not as important as the primary action.
 
 <ComponentPreview name="button-link" />
 
-### Icon
+### Only an Icon
+
+Dispaying only an Icon in a button.
+
+<Admonition type="note" title="This feature requires more support" className="mt-3">
+  We should update the button component to support this use case better.
+</Admonition>
 
 <ComponentPreview name="button-icon" />
 
-### With Icon
-
-<ComponentPreview name="button-with-icon" />
-
-### Loading
-
-<ComponentPreview name="button-loading" />
-
 ### As Child
+
+Supports slot behavior with `asChild` prop.
 
 <ComponentPreview name="button-as-child" />

--- a/apps/design-system/registry/default/example/button-default.tsx
+++ b/apps/design-system/registry/default/example/button-default.tsx
@@ -1,17 +1,17 @@
 import { Mail } from 'lucide-react'
 import { Button } from 'ui'
 
-export default function ButtonGhost() {
+export default function ButtonDemo() {
   return (
     <div className="flex gap-3">
-      <Button type="text">Button rest</Button>
-      <Button type="text" loading>
+      <Button type="default">Button rest</Button>
+      <Button type="default" loading>
         Button loading
       </Button>
-      <Button type="text" icon={<Mail />}>
+      <Button type="default" icon={<Mail />}>
         Button icon
       </Button>
-      <Button type="text" iconRight={<Mail />}>
+      <Button type="default" iconRight={<Mail />}>
         Button iconRight
       </Button>
     </div>

--- a/apps/design-system/registry/default/example/button-demo.tsx
+++ b/apps/design-system/registry/default/example/button-demo.tsx
@@ -1,5 +1,19 @@
+import { Mail } from 'lucide-react'
 import { Button } from 'ui'
 
 export default function ButtonDemo() {
-  return <Button>Button</Button>
+  return (
+    <div className="flex gap-3">
+      <Button type="primary">Button rest</Button>
+      <Button type="primary" loading>
+        Button loading
+      </Button>
+      <Button type="primary" icon={<Mail />}>
+        Button icon
+      </Button>
+      <Button type="primary" iconRight={<Mail />}>
+        Button iconRight
+      </Button>
+    </div>
+  )
 }

--- a/apps/design-system/registry/default/example/button-destructive.tsx
+++ b/apps/design-system/registry/default/example/button-destructive.tsx
@@ -1,5 +1,19 @@
+import { Mail } from 'lucide-react'
 import { Button } from 'ui'
 
 export default function ButtonDestructive() {
-  return <Button type="danger">Destructive</Button>
+  return (
+    <div className="flex gap-3">
+      <Button type="danger">Button rest</Button>
+      <Button type="danger" loading>
+        Button loading
+      </Button>
+      <Button type="danger" icon={<Mail />}>
+        Button icon
+      </Button>
+      <Button type="danger" iconRight={<Mail />}>
+        Button iconRight
+      </Button>
+    </div>
+  )
 }

--- a/apps/design-system/registry/default/example/button-link.tsx
+++ b/apps/design-system/registry/default/example/button-link.tsx
@@ -1,5 +1,19 @@
+import { Mail } from 'lucide-react'
 import { Button } from 'ui'
 
 export default function ButtonLink() {
-  return <Button type="link">Link</Button>
+  return (
+    <div className="flex gap-3">
+      <Button type="link">Button rest</Button>
+      <Button type="link" loading>
+        Button loading
+      </Button>
+      <Button type="link" icon={<Mail />}>
+        Button icon
+      </Button>
+      <Button type="link" iconRight={<Mail />}>
+        Button iconRight
+      </Button>
+    </div>
+  )
 }

--- a/apps/design-system/registry/default/example/button-outline.tsx
+++ b/apps/design-system/registry/default/example/button-outline.tsx
@@ -1,5 +1,19 @@
+import { Mail } from 'lucide-react'
 import { Button } from 'ui'
 
 export default function ButtonOutline() {
-  return <Button type="outline">Outline</Button>
+  return (
+    <div className="flex gap-3">
+      <Button type="outline">Button rest</Button>
+      <Button type="outline" loading>
+        Button loading
+      </Button>
+      <Button type="outline" icon={<Mail />}>
+        Button icon
+      </Button>
+      <Button type="outline" iconRight={<Mail />}>
+        Button iconRight
+      </Button>
+    </div>
+  )
 }

--- a/apps/design-system/registry/default/example/button-secondary.tsx
+++ b/apps/design-system/registry/default/example/button-secondary.tsx
@@ -1,5 +1,19 @@
+import { Mail } from 'lucide-react'
 import { Button } from 'ui'
 
 export default function ButtonSecondary() {
-  return <Button type="secondary">Secondary</Button>
+  return (
+    <div className="flex gap-3">
+      <Button type="secondary">Button rest</Button>
+      <Button type="secondary" loading>
+        Button loading
+      </Button>
+      <Button type="secondary" icon={<Mail />}>
+        Button icon
+      </Button>
+      <Button type="secondary" iconRight={<Mail />}>
+        Button iconRight
+      </Button>
+    </div>
+  )
 }

--- a/apps/design-system/registry/default/example/button-sizes.tsx
+++ b/apps/design-system/registry/default/example/button-sizes.tsx
@@ -1,0 +1,24 @@
+import { Mail } from 'lucide-react'
+import { Button } from 'ui'
+
+export default function ButtonDemo() {
+  return (
+    <div className="flex gap-3">
+      <Button type="default" size="tiny">
+        Tiny Button
+      </Button>
+      <Button type="default" size="small">
+        Small button
+      </Button>
+      <Button type="default" size="medium">
+        Medium button
+      </Button>
+      <Button type="default" size="large">
+        Large button
+      </Button>
+      <Button type="default" size="xlarge">
+        Huge button
+      </Button>
+    </div>
+  )
+}

--- a/apps/design-system/registry/default/example/button-warning.tsx
+++ b/apps/design-system/registry/default/example/button-warning.tsx
@@ -1,17 +1,17 @@
 import { Mail } from 'lucide-react'
 import { Button } from 'ui'
 
-export default function ButtonGhost() {
+export default function ButtonDemo() {
   return (
     <div className="flex gap-3">
-      <Button type="text">Button rest</Button>
-      <Button type="text" loading>
+      <Button type="warning">Button rest</Button>
+      <Button type="warning" loading>
         Button loading
       </Button>
-      <Button type="text" icon={<Mail />}>
+      <Button type="warning" icon={<Mail />}>
         Button icon
       </Button>
-      <Button type="text" iconRight={<Mail />}>
+      <Button type="warning" iconRight={<Mail />}>
         Button iconRight
       </Button>
     </div>

--- a/apps/design-system/registry/examples.ts
+++ b/apps/design-system/registry/examples.ts
@@ -122,6 +122,24 @@ export const examples: Registry = [
     files: ['example/button-demo.tsx'],
   },
   {
+    name: 'button-sizes',
+    type: 'components:example',
+    registryDependencies: ['button'],
+    files: ['example/button-sizes.tsx'],
+  },
+  {
+    name: 'button-default',
+    type: 'components:example',
+    registryDependencies: ['button'],
+    files: ['example/button-default.tsx'],
+  },
+  {
+    name: 'button-warning',
+    type: 'components:example',
+    registryDependencies: ['button'],
+    files: ['example/button-warning.tsx'],
+  },
+  {
     name: 'button-secondary',
     type: 'components:example',
     registryDependencies: ['button'],

--- a/apps/docs/content/guides/auth/redirect-urls.mdx
+++ b/apps/docs/content/guides/auth/redirect-urls.mdx
@@ -64,9 +64,9 @@ const getURL = () => {
     process?.env?.NEXT_PUBLIC_VERCEL_URL ?? // Automatically set by Vercel.
     'http://localhost:3000/'
   // Make sure to include `https://` when not localhost.
-  url = url.includes('http') ? url : `https://${url}`
+  url = url.startsWith('http') ? url : `https://${url}`
   // Make sure to include a trailing `/`.
-  url = url.charAt(url.length - 1) === '/' ? url : `${url}/`
+  url = url.endsWith('/') ? url : `${url}/`
   return url
 }
 

--- a/apps/docs/content/guides/platform/branching.mdx
+++ b/apps/docs/content/guides/platform/branching.mdx
@@ -537,7 +537,7 @@ We highly recommend turning on a 'required check' for the Supabase integration. 
 
 ### Disable branching
 
-You can disable branching at any time. Navigate to the [Branches](https://supabase.green/dashboard/project/_/branches) page, which can be found via the Branches dropdown menu on the top navigation, then click "Manage Branches" in the menu. Click the 'Disable branching' button at the top of the Overview section.
+You can disable branching at any time. Navigate to the [Branches](/dashboard/project/_/branches) page, which can be found via the Branches dropdown menu on the top navigation, then click "Manage Branches" in the menu. Click the 'Disable branching' button at the top of the Overview section.
 
 ## Migration and seeding behavior
 

--- a/apps/docs/content/guides/storage/debugging/logs.mdx
+++ b/apps/docs/content/guides/storage/debugging/logs.mdx
@@ -5,7 +5,7 @@ description: 'Learn how to check Storage Logs'
 sidebar_label: 'Debugging'
 ---
 
-Accessing the [Storage Logs](https://supabase.green/dashboard/project/__/logs/explorer?q=select+id%2C+storage_logs.timestamp%2C+event_message+from+storage_logs%0A++%0A++order+by+timestamp+desc%0A++limit+100%0A++) allows you to examine all incoming request logs to your Storage service. You can also filter logs and delve into specific aspects of your requests.
+Accessing the [Storage Logs](/dashboard/project/__/logs/explorer?q=select+id%2C+storage_logs.timestamp%2C+event_message+from+storage_logs%0A++%0A++order+by+timestamp+desc%0A++limit+100%0A++) allows you to examine all incoming request logs to your Storage service. You can also filter logs and delve into specific aspects of your requests.
 
 ### Common log queries
 

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -179,7 +179,7 @@ const Nav = (props: Props) => {
                         <Button type="default" className="hidden lg:block" asChild>
                           <Link href="https://supabase.com/dashboard">Sign in</Link>
                         </Button>
-                        <Button className="hidden text-white lg:block" asChild>
+                        <Button className="hidden lg:block" asChild>
                           <Link href="https://supabase.com/dashboard">Start your project</Link>
                         </Button>
                       </>

--- a/apps/www/components/Sections/ProductHeader.tsx
+++ b/apps/www/components/Sections/ProductHeader.tsx
@@ -43,7 +43,7 @@ const ProductHeader = (props: Types) => (
             })}
         </div>
         <div className="flex flex-row md:flex-row md:items-center">
-          <Button asChild size="medium" className="text-white">
+          <Button asChild size="medium">
             <Link href="https://supabase.com/dashboard" as="https://supabase.com/dashboard">
               Start a project
             </Link>

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -173,6 +173,8 @@ export {
   SelectSeparator as SelectSeparator_Shadcn_,
   SelectTrigger as SelectTrigger_Shadcn_,
   SelectValue as SelectValue_Shadcn_,
+  SelectScrollUpButton as SelectScrollUpButton_Shadcn_,
+  SelectScrollDownButton as SelectScrollDownButton_Shadcn_,
 } from './src/components/shadcn/ui/select'
 
 export {

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -2,12 +2,11 @@
 
 import { Slot } from '@radix-ui/react-slot'
 import { VariantProps, cva } from 'class-variance-authority'
+import { Loader2 } from 'lucide-react'
 import { cloneElement, forwardRef, isValidElement } from 'react'
 import { SIZE_VARIANTS, SIZE_VARIANTS_DEFAULT } from '../../lib/constants'
 import { cn } from '../../lib/utils/cn'
 import { IconContext } from '../Icon/IconContext'
-import { IconLoader } from '../Icon/icons/IconLoader'
-import { Loader } from 'lucide-react'
 
 export type ButtonVariantProps = VariantProps<typeof buttonVariants>
 const buttonVariants = cva(
@@ -33,104 +32,103 @@ const buttonVariants = cva(
     variants: {
       type: {
         primary: `
-            bg-brand-button hover:bg-brand-button/80
-            text-white
-            border-brand
-            focus-visible:outline-brand-600
-            shadow-sm
-            data-[state=open]:bg-brand-button/80
-            data-[state=open]:outline-brand-600
-            `,
-        secondary: `
-            bg-foreground
-            text-background hover:text-border-stronger
-            focus-visible:text-border-control
-            border-foreground-light hover:border-foreground-lighter
-            focus-visible:outline-border-strong
-            data-[state=open]:border-foreground-lighter
-            data-[state=open]:outline-border-strong
-            shadow-sm`,
+          bg-brand-400 dark:bg-brand-500 
+          hover:bg-brand/80 dark:hover:bg-brand/50
+          text-foreground
+          border-brand-500/75 dark:border-brand/30
+          hover:border-brand-600 dark:hover:border-brand
+          focus-visible:outline-brand-600
+          data-[state=open]:bg-brand-400/80 dark:data-[state=open]:bg-brand-500/80
+          data-[state=open]:outline-brand-600
+          `,
         default: `
-            text-foreground
-            bg-button hover:bg-selection
-            border-button hover:border-button-hover
-            focus-visible:outline-brand-600
-            data-[state=open]:bg-selection
-            data-[state=open]:outline-brand-600
-            data-[state=open]:border-button-hover
-            shadow-sm`,
+          text-foreground
+          bg-alternative dark:bg-muted  hover:bg-selection
+          border-strong hover:border-stronger
+          focus-visible:outline-brand-600
+          data-[state=open]:bg-selection
+          data-[state=open]:outline-brand-600
+          data-[state=open]:border-button-hover
+          `,
+        secondary: `
+          bg-foreground
+          text-background hover:text-border-stronger
+          focus-visible:text-border-control
+          border-foreground-light hover:border-foreground-lighter
+          focus-visible:outline-border-strong
+          data-[state=open]:border-foreground-lighter
+          data-[state=open]:outline-border-strong
+        `,
+        // @deprecated use 'primary' instead
         alternative: `
-            text-foreground
-            bg-brand-400 hover:bg-brand-500
-            border-brand-500
-            focus-visible:border-brand-500
-            focus-visible:outline-brand-600
-            data-[state=open]:bg-brand-500
-            data-[state=open]:border-brand-500
-            data-[state=open]:outline-brand-600
-            shadow-sm`,
+          text-foreground
+          bg-brand-400 hover:bg-brand-500
+          border-brand-500
+          focus-visible:border-brand-500
+          focus-visible:outline-brand-600
+          data-[state=open]:bg-brand-500
+          data-[state=open]:border-brand-500
+          data-[state=open]:outline-brand-600
+        `,
         outline: `
-            text-foreground
-            bg-transparent
-            border-strong hover:border-stronger
-            focus-visible:outline-border-strong
-            data-[state=open]:border-stronger
-            data-[state=open]:outline-border-strong
-            `,
+          text-foreground
+          bg-transparent
+          border-strong hover:border-foreground-muted
+          focus-visible:outline-border-strong
+          data-[state=open]:border-stronger
+          data-[state=open]:outline-border-strong
+        `,
         dashed: `
-            text-foreground
-            border
-            border-dashed
-            border-strong hover:border-stronger
-            bg-transparent
-            focus-visible:outline-border-strong
-            data-[state=open]:border-stronger
-            data-[state=open]:outline-border-strong
-            shadow-sm`,
+          text-foreground
+          border
+          border-dashed
+          border-strong hover:border-stronger
+          bg-transparent
+          focus-visible:outline-border-strong
+          data-[state=open]:border-stronger
+          data-[state=open]:outline-border-strong
+        `,
         link: `
-            text-brand-600
-            border
-            border-transparent
-            hover:bg-brand-400
-            border-opacity-0
-            bg-opacity-0
-            shadow-none
-            focus-visible:outline-border-strong
-            data-[state=open]:bg-brand-400
-            data-[state=open]:outline-border-strong
-            `,
+          text-brand-600
+          border
+          border-transparent
+          hover:bg-brand-400
+          border-opacity-0
+          bg-opacity-0
+          shadow-none
+          focus-visible:outline-border-strong
+          data-[state=open]:bg-brand-400
+          data-[state=open]:outline-border-strong
+        `,
         text: `
-            text-foreground
-            hover:bg-surface-300
-            shadow-none
-            focus-visible:outline-border-strong
-            data-[state=open]:bg-surface-300
-            data-[state=open]:outline-border-strong
-            border-transparent`,
+          text-foreground
+          hover:bg-surface-300
+          shadow-none
+          focus-visible:outline-border-strong
+          data-[state=open]:bg-surface-300
+          data-[state=open]:outline-border-strong
+          border-transparent
+        `,
         danger: `
-            text-red-1100
-            bg-red-200
-            border-red-700 hover:border-red-900
-            hover:bg-red-900
-            hover:text-lo-contrast
-            focus-visible:outline-red-700
-            data-[state=open]:border-red-900
-            data-[state=open]:bg-red-900
-            data-[state=open]:text-lo-contrast
-            data-[state=open]:outline-red-700
-            shadow-sm`,
+          text-foreground
+          bg-destructive-300 dark:bg-destructive-400 hover:bg-destructive-400 dark:hover:bg-destructive/50
+          border-destructive-500 hover:border-destructive
+          hover:text-hi-contrast
+          focus-visible:outline-amber-700
+          data-[state=open]:border-destructive
+          data-[state=open]:bg-destructive-400 dark:data-[state=open]:bg-destructive-/50
+          data-[state=open]:outline-destructive
+        `,
         warning: `
-            text-amber-1100
-            bg-amber-200
-            border-amber-700 hover:border-amber-900
-            hover:bg-amber-900
-            hover:text-hi-contrast
-            focus-visible:outline-amber-700
-            data-[state=open]:border-amber-900
-            data-[state=open]:bg-amber-900
-            data-[state=open]:text-hi-contrast
-            data-[state=open]:outline-amber-700
-            shadow-sm`,
+          text-foreground
+          bg-warning-300 dark:bg-warning-400 hover:bg-warning-400 dark:hover:bg-warning/50
+          border-warning-500 hover:border-warning
+          hover:text-hi-contrast
+          focus-visible:outline-amber-700
+          data-[state=open]:border-warning
+          data-[state=open]:bg-warning-400 dark:data-[state=open]:bg-warning-/50
+          data-[state=open]:outline-warning
+        `,
       },
       block: {
         true: 'w-full flex items-center justify-center',
@@ -143,7 +141,7 @@ const buttonVariants = cva(
         container: `fixed inset-0 transition-opacity`,
       },
       disabled: {
-        true: 'opacity-50 cursor-default',
+        true: 'opacity-50 cursor-not-allowed pointer-events-none',
       },
       rounded: {
         true: 'rounded-full',
@@ -170,12 +168,36 @@ const IconContainerVariants = cva('', {
       xxlarge: '[&_svg]:h-[30px] [&_svg]:w-[30px]',
       xxxlarge: '[&_svg]:h-[42px] [&_svg]:w-[42px]',
     },
+    type: {
+      primary: 'text-brand-600',
+      default: 'text-foreground-muted',
+      secondary: 'text-border-muted',
+      alternative: 'text-foreground-muted',
+      outline: 'text-foreground-muted',
+      dashed: 'text-foreground-muted',
+      link: 'text-brand-600',
+      text: 'text-foreground-muted',
+      danger: 'text-destructive-600',
+      warning: 'text-warning-600',
+    },
   },
 })
 
 export type LoadingVariantProps = VariantProps<typeof loadingVariants>
 const loadingVariants = cva('', {
   variants: {
+    type: {
+      primary: 'text-brand-600',
+      default: 'text-foreground-muted',
+      secondary: 'text-border-muted',
+      alternative: 'text-foreground-muted',
+      outline: 'text-foreground-muted',
+      dashed: 'text-foreground-muted',
+      link: 'text-brand-600',
+      text: 'text-foreground-muted',
+      danger: 'text-destructive-600',
+      warning: 'text-warning-600',
+    },
     loading: {
       default: '',
       true: `animate-spin`,
@@ -189,7 +211,7 @@ export interface ButtonProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type'>,
     // omit 'disabled' as it is included in HTMLButtonElement
     Omit<ButtonVariantProps, 'disabled'>,
-    LoadingVariantProps {
+    Omit<LoadingVariantProps, 'type'> {
   asChild?: boolean
   type?: ButtonVariantProps['type']
   htmlType?: React.ButtonHTMLAttributes<HTMLButtonElement>['type']
@@ -241,17 +263,17 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
               undefined,
               showIcon &&
                 (loading ? (
-                  <div className={cn(IconContainerVariants({ size }))}>
-                    <Loader className={cn(loadingVariants({ loading }))} />
+                  <div className={cn(IconContainerVariants({ size, type }))}>
+                    <Loader2 className={cn(loadingVariants({ loading, type }))} />
                   </div>
                 ) : _iconLeft ? (
-                  <div className={cn(IconContainerVariants({ size }))}>{_iconLeft}</div>
+                  <div className={cn(IconContainerVariants({ size, type }))}>{_iconLeft}</div>
                 ) : null),
               children.props.children && (
                 <span className={'truncate'}>{children.props.children}</span>
               ),
               iconRight && !loading && (
-                <div className={cn(IconContainerVariants({ size }))}>{iconRight}</div>
+                <div className={cn(IconContainerVariants({ size, type }))}>{iconRight}</div>
               )
             )
           ) : null
@@ -259,15 +281,15 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           <>
             {showIcon &&
               (loading ? (
-                <div className={cn(IconContainerVariants({ size }))}>
-                  <Loader className={cn(loadingVariants({ loading }))} />
+                <div className={cn(IconContainerVariants({ size, type }))}>
+                  <Loader2 className={cn(loadingVariants({ loading, type }))} />
                 </div>
               ) : _iconLeft ? (
-                <div className={cn(IconContainerVariants({ size }))}>{_iconLeft}</div>
+                <div className={cn(IconContainerVariants({ size, type }))}>{_iconLeft}</div>
               ) : null)}{' '}
             {children && <span className={'truncate'}>{children}</span>}{' '}
             {iconRight && !loading && (
-              <IconContext.Provider value={{ contextSize: size }}>{iconRight}</IconContext.Provider>
+              <div className={cn(IconContainerVariants({ size, type }))}>{iconRight}</div>
             )}
           </>
         )}

--- a/packages/ui/src/components/shadcn/ui/select.tsx
+++ b/packages/ui/src/components/shadcn/ui/select.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as SelectPrimitive from '@radix-ui/react-select'
-import { Check, ChevronDown } from 'lucide-react'
+import { Check, ChevronDown, ChevronUp } from 'lucide-react'
 import * as React from 'react'
 
 import { cn } from '../../../lib/utils/cn'
@@ -47,6 +47,40 @@ const SelectTrigger = React.forwardRef<
 ))
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
 
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1 text-foreground-muted',
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1 text-foreground-muted',
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName
+
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
@@ -55,13 +89,15 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-overlay text-popover-foreground shadow-md animate-in fade-in-80',
-        position === 'popper' && 'translate-y-1',
+        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-overlay text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className
       )}
       position={position}
       {...props}
     >
+      <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
           'p-1',
@@ -71,6 +107,7 @@ const SelectContent = React.forwardRef<
       >
         {children}
       </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
 ))
@@ -82,7 +119,10 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn('py-1.5 pl-8 pr-2 text-xs text-foreground-lighter', className)}
+    className={cn(
+      'py-1.5 pl-8 pr-2 text-xs text-foreground-lighter/75 uppercase tracking-wider font-mono',
+      className
+    )}
     {...props}
   />
 ))
@@ -96,7 +136,7 @@ const SelectItem = React.forwardRef<
     ref={ref}
     className={cn(
       'group',
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-xs outline-none focus:bg-overlay-hover text-foreground-lighter focus:text-foreground data-[state=checked]:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-xs outline-none focus:bg-overlay-hover text-foreground-light focus:text-foreground data-[state=checked]:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}
@@ -133,4 +173,6 @@ export {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

### Description

This PR removes the settings related to Supabase Studio from the `.env.sample` file in the `/docker` directory. Since Supabase Studio is not supported in self-hosted environments, including these settings can cause confusion among users.

### Changes Made

- Removed the `STUDIO_DEFAULT_ORGANIZATION`, `STUDIO_DEFAULT_PROJECT`, and `STUDIO_PORT` settings from the `.env.sample` file.

### Issue

The current `.env.sample` file includes settings for Supabase Studio, which is not supported in self-hosted environments. This can lead to confusion and misconfiguration for users attempting to self-host Supabase.

### Solution

By removing these settings, we can prevent confusion and ensure users have a clearer understanding of the supported configurations for self-hosting.

